### PR TITLE
try child approach

### DIFF
--- a/child/_child_enable_actions.Rmd
+++ b/child/_child_enable_actions.Rmd
@@ -1,0 +1,13 @@
+## Enable workflow actions
+
+<input type="checkbox">  In your OTTR repository, go to **Settings** in the top navigation tabs <img src="resources/icons/settings_gear.png" alt="settings icon" class = icon>
+
+<input type="checkbox">  Go to **Actions** (General) in the side navigation <img src="resources/icons/actions.png" alt="actions icon" class = icon>
+
+<input type="checkbox">  Under **Workflow permissions**
+
+1. <input type="checkbox"> Select **Read and write permissions**
+
+2. <input type="checkbox">  Check **Allow GitHub Actions to create and approve pull requests**
+
+3. <input type="checkbox">  Click **Save**

--- a/child/_child_header.Rmd
+++ b/child/_child_header.Rmd
@@ -1,0 +1,22 @@
+```{r, include = FALSE}
+if (!exists("cheatsheet_settings")) {
+  cheatsheet_settings <- list()
+}
+if (is.null(cheatsheet_settings$title)){
+  cheatsheet_settings$title <- "OTTR"
+  cheatsheet_settings$subtitle <- "Instructions"
+}
+```
+
+---
+title: |
+  <center> <u>`r cheatsheet_settings$title`</u></center>
+  <center> <p style = "color:#986753;">`r cheatsheet_settings$subtitle`</p></center>
+date: "Last updated: `r format(Sys.time(), '%B %d, %Y')`"
+output: html_document
+css: style.css
+---
+
+```{r, include = FALSE}
+AnVIL_module_settings <<- NULL
+```

--- a/child/_child_use_template.Rmd
+++ b/child/_child_use_template.Rmd
@@ -1,0 +1,20 @@
+```{r, include = FALSE}
+if (!exists("cheatsheet_settings")) {
+  cheatsheet_settings <- list()
+}
+if (is.null(cheatsheet_settings$title)){
+  cheatsheet_settings$template_name <- "TEMPLATE NAME"
+  cheatsheet_settings$template_url <- "https://github.com/jhudsl/TEMPLATEURL"
+}
+```
+
+## Create your OTTR repository from the [`r cheatsheet_settings$template_name` repository](`r cheatsheet_settings$template_url`)
+
+<input type="checkbox">  In the upper right, _click on_: <div class = "github_button"><a href='<%#String.Concat("https://github.com/new?template_name=",`r cheatsheet_settings$template_name`,
+                 "&template_owner=jhudsl")%>'Use this template</a></div>
+
+<input type="checkbox">  Set your repo to **Public**
+
+```{r, include = FALSE}
+AnVIL_module_settings <<- NULL
+```

--- a/course_setup_childApproach.Rmd
+++ b/course_setup_childApproach.Rmd
@@ -1,0 +1,38 @@
+```{r echo=FALSE}
+library(cow)
+```
+
+```{r, echo = FALSE, results='asis'}
+
+# Specify variables
+cheatsheet_settings <- list(
+  title = "OTTR Courses",
+  subtitle = "Setup"
+)
+
+cow::borrow_chapter(
+  doc_path = "child/_child_header.Rmd",
+  repo_name = "fhdsl/cheatsheets",
+)
+```
+
+```{r, echo = FALSE, results='asis'}
+
+# Specify variables
+cheatsheet_settings <- list(
+  template_name = "OTTR_Template",
+  template_url = "https://github.com/jhudsl/OTTR_Template"
+)
+
+cow::borrow_chapter(
+  doc_path = "child/_child_use_template.Rmd",
+  repo_name = "fhdsl/cheatsheets",
+)
+```
+
+```{r, echo = FALSE, results='asis'}
+cow::borrow_chapter(
+  doc_path = "child/_child_enable_actions.Rmd",
+  repo_name = "fhdsl/cheatsheets",
+)
+```


### PR DESCRIPTION
Trying the child approach that AnVIL Template uses to build a cheatsheet, borrowing chunks from child Rmds to make this process drier. Not sure that a render preview will work since I'm asking cow to borrow chapters that are in this PR not on main from this repo. Also am trying to concatenate a URL in `_child_use_template.Rmd` that I'm not sure will work...