### PR TITLE
Tiny fixes

### DIFF
--- a/attending_conferences.Rmd
+++ b/attending_conferences.Rmd
@@ -2,6 +2,8 @@
 output:
   html_document:
     number_sections: false
+    includes:
+      in_header: itn_favicon.html
 css: css/ITN_style.css
 ---
 

--- a/chunks/create_itn_header.md
+++ b/chunks/create_itn_header.md
@@ -1,5 +1,3 @@
-<link rel="shortcut icon" href="css/images/ITN_favicon.ico " />
- <!--- go to https://favicon.io/favicon-converter/ to upload an image to make a new favicon.io. You will need to replace the current favicon.io image with the one in the downloaded directory from the website. The current image is in the resources/images/ directory --->
 
 <div class = "header_box">
 <u>{TITLE}</u><br><span style = "color:#14395f;"> {SUBTITLE} </span>

--- a/chunks/create_ottr_footer.md
+++ b/chunks/create_ottr_footer.md
@@ -1,4 +1,6 @@
 
+<br>
+<br>
 <center>
 <a href="https://www.ottrproject.org/">
   <img src="css/images/basic_otter_water.png" width = 40%>

--- a/chunks/create_ottr_header.md
+++ b/chunks/create_ottr_header.md
@@ -1,5 +1,3 @@
-<link rel="shortcut icon" href="css/images/basic_ottr_water.ico " />
- <!--- go to https://favicon.io/favicon-converter/ to upload an image to make a new favicon.io. You will need to replace the current favicon.io image with the one in the downloaded directory from the website. The current image is in the resources/images/ directory --->
 
 <div class = "header_box">
 <u>{TITLE}</u><br><span style = "color:#986753;"> {SUBTITLE} </span>

--- a/chunks/create_repository.md
+++ b/chunks/create_repository.md
@@ -1,4 +1,0 @@
-
-<input type="checkbox">  In the upper right, _click on_: <div class = "github_button"><a href="https://github.com/new?template_name={TEMPLATE_NAME}&template_owner={TEMPLATE_NAME}"> Use this template</a></div>
-
-<input type="checkbox">  Set your repo to **Public**

--- a/chunks/secrets.md
+++ b/chunks/secrets.md
@@ -1,4 +1,4 @@
-## Save the copied personal access token as a [repository secret](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-development-environment-secrets-for-your-repository-or-organization#adding-secrets-for-a-repository)
+## Save the copied personal access token as a repository secret
 
 <input type="checkbox"> In your OTTR repository, go to **Settings** in the top navigation tabs `r config::get("settings")`
 
@@ -13,3 +13,5 @@
 <input type="checkbox"> For **Secret**, paste your copied personal access token
 
 <input type="checkbox"> Click on: <div class = "github_button"> Add secret </div>
+
+[Click here to see GitHub documentation on setting repository secrets.](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-development-environment-secrets-for-your-repository-or-organization#adding-secrets-for-a-repository)

--- a/chunks/secrets.md
+++ b/chunks/secrets.md
@@ -14,4 +14,6 @@
 
 <input type="checkbox"> Click on: <div class = "github_button"> Add secret </div>
 
+<br>
+
 [Click here to see GitHub documentation on setting repository secrets.](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-development-environment-secrets-for-your-repository-or-organization#adding-secrets-for-a-repository)

--- a/chunks/secrets.md
+++ b/chunks/secrets.md
@@ -1,4 +1,4 @@
-## [Save the copied personal access token as a repository secret](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-development-environment-secrets-for-your-repository-or-organization#adding-secrets-for-a-repository)
+## Save the copied personal access token as a [repository secret](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-development-environment-secrets-for-your-repository-or-organization#adding-secrets-for-a-repository)
 
 <input type="checkbox"> In your OTTR repository, go to **Settings** in the top navigation tabs `r config::get("settings")`
 

--- a/chunks/starter_template.md
+++ b/chunks/starter_template.md
@@ -3,4 +3,4 @@
 
 <input type="checkbox">  In the upper right, _click on_: <div class = "github_button"> <a href="https://github.com/new?template_name={TEMPLATE_NAME}"> Use this template</a></div>
 
-<input type="checkbox">  Set your repo to **Public**'
+<input type="checkbox">  Set your repo to "**Public**"

--- a/chunks/token.md
+++ b/chunks/token.md
@@ -14,4 +14,6 @@
 
 <input type="checkbox"> Copy the **personal access token** `r config::get("copy")`
 
+<br>
+
 [Click here to see GitHub documentation on creating a personal access token.](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)

--- a/chunks/token.md
+++ b/chunks/token.md
@@ -1,7 +1,5 @@
 ## Set up your GitHub personal access token
 
-[Create a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
-
 <input type="checkbox"> Click on your **profile photo** in the upper right `r config::get("profile")`
 
 <input type="checkbox"> Go to **Settings** `r config::get("settings")`
@@ -15,3 +13,5 @@
 <input type="checkbox"> Click: <div class = "github_button"><a href="https://github.com/settings/tokens/new"> Generate Token</a></div>
 
 <input type="checkbox"> Copy the **personal access token** `r config::get("copy")`
+
+[Click here to see GitHub documentation on creating a personal access token.](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)

--- a/css/ITN_style.css
+++ b/css/ITN_style.css
@@ -100,9 +100,9 @@ input[type="checkbox"] {
 /*------------- png boxes button style---------------- */
 
 .png_button {
-    position: absolute;
-    top: 20px;
-    right: 5%;
+    position: absolute; /*----placement of button--*/
+    top: 20px; /*----placement of button--*/
+    right: 5%; /*----placement of button--*/
     border: 4px solid #black;
     border-radius: 8px;
     background: #e8ebee;
@@ -118,6 +118,7 @@ input[type="checkbox"] {
 }
 
 .time {
+  margin-top:20px;
   font-size: 20px;
 }
 
@@ -157,6 +158,7 @@ body {
   font-size: 15px;
   line-height: 1.4;
 }
+
 h2::before {
   counter-increment: h2;
   content: counter(h2) ". ";

--- a/css/OTTR_style.css
+++ b/css/OTTR_style.css
@@ -35,9 +35,9 @@ input[type="checkbox"] {
 /*------------- png boxes button style---------------- */
 
 .png_button {
-    position: absolute;
-    top: 20px;
-    left: 5%;
+    position: absolute; /*----placement of button--*/
+    top: 20px; /*----placement of button--*/
+    right: 5%; /*----placement of button--*/
     border: 4px solid #black;
     border-radius: 8px;
     background: lightgray;
@@ -54,6 +54,7 @@ input[type="checkbox"] {
 
 /*------------- timestamp style---------------- */
 .time {
+  margin-top:60px;
   font-size: 20px;
 }
 
@@ -80,9 +81,10 @@ div.authors {
 /*------------- box around title and title font ---------------- */
 
 .header_box {
-  position: absolute;
-  top: 20px;
-  left: 30%;
+ /*-- position: absolute; --- */
+ /*-- top: 20px;--- */
+ /*-- left: 30%;--- */
+  margin: auto;
   font-family: 'Avenir';
   font-size: 40px;
   color: #193a5c;
@@ -132,9 +134,11 @@ a {
 /*------------- Numbering for header level 2 ---------------- */
 
 body {
-  padding-top: 300px; /*--leave room after header---*/
+  margin-top:100px; /*--leave room after header---*/
+ /*- padding-top: 50px;--- */
   counter-reset: h2;
 }
+
 h2::before {
   counter-increment: h2;
   content: counter(h2) ". ";

--- a/css/OTTR_style.css
+++ b/css/OTTR_style.css
@@ -81,13 +81,11 @@ div.authors {
 /*------------- box around title and title font ---------------- */
 
 .header_box {
- /*-- position: absolute; --- */
- /*-- top: 20px;--- */
- /*-- left: 30%;--- */
   margin: auto;
   font-family: 'Avenir';
   font-size: 40px;
   color: #193a5c;
+  font-weight: 500;
   border-radius: 8px; /*---rounded box ---*/
   border: 4px solid #986753;
   background: #90ceff;

--- a/css/OTTR_style.css
+++ b/css/OTTR_style.css
@@ -78,6 +78,10 @@ div.authors {
     color: black;
 }
 
+.github_button a:visited{
+    color: #fff;
+}
+
 /*------------- box around title and title font ---------------- */
 
 .header_box {

--- a/itn_favicon.html
+++ b/itn_favicon.html
@@ -1,0 +1,2 @@
+<link rel="shortcut icon" href="../css/images/ITN_favicon.ico" />
+ <!--- go to https://favicon.io/favicon-converter/ to upload an image to make a new favicon.io. You will need to replace the current favicon.io image with the one in the downloaded directory from the website. The current image is in the resources/images/ directory --->

--- a/itn_favicon.html
+++ b/itn_favicon.html
@@ -1,2 +1,2 @@
-<link rel="shortcut icon" href="../css/images/ITN_favicon.ico" />
+<link rel="shortcut icon" href="css/images/ITN_favicon.ico" />
  <!--- go to https://favicon.io/favicon-converter/ to upload an image to make a new favicon.io. You will need to replace the current favicon.io image with the one in the downloaded directory from the website. The current image is in the resources/images/ directory --->

--- a/ottr_course.Rmd
+++ b/ottr_course.Rmd
@@ -1,5 +1,8 @@
 ---
-output: html_document
+output:
+  html_document:
+    includes:
+      in_header: ottr_favicon.html
 css: css/OTTR_style.css
 ---
 

--- a/ottr_favicon.html
+++ b/ottr_favicon.html
@@ -1,3 +1,3 @@
-<link rel="shortcut icon" href="/css/images/basic_ottr_water.ico" />
+<link rel="shortcut icon" href="/css/images/basic_otter_water.ico" />
 <!--- go to https://favicon.io/favicon-converter/ to upload an image to make a new favicon.io. You will need to replace the current favicon.io image with the one in the downloaded directory from the website. The current image is in the resources/images/ directory --->
 

--- a/ottr_favicon.html
+++ b/ottr_favicon.html
@@ -1,0 +1,3 @@
+<link rel="shortcut icon" href="/css/images/basic_ottr_water.ico" />
+<!--- go to https://favicon.io/favicon-converter/ to upload an image to make a new favicon.io. You will need to replace the current favicon.io image with the one in the downloaded directory from the website. The current image is in the resources/images/ directory --->
+

--- a/ottr_favicon.html
+++ b/ottr_favicon.html
@@ -1,3 +1,3 @@
-<link rel="shortcut icon" href="/css/images/basic_otter_water.ico" />
+<link rel="shortcut icon" href="css/images/basic_otter_water.ico" />
 <!--- go to https://favicon.io/favicon-converter/ to upload an image to make a new favicon.io. You will need to replace the current favicon.io image with the one in the downloaded directory from the website. The current image is in the resources/images/ directory --->
 

--- a/ottr_quarto_course.Rmd
+++ b/ottr_quarto_course.Rmd
@@ -1,5 +1,8 @@
 ---
-output: html_document
+output:
+  html_document:
+    includes:
+      in_header: ottr_favicon.html
 css: css/OTTR_style.css
 ---
 

--- a/ottr_quarto_website.Rmd
+++ b/ottr_quarto_website.Rmd
@@ -1,5 +1,8 @@
 ---
-output: html_document
+output:
+  html_document:
+    includes:
+      in_header: ottr_favicon.html
 css: css/OTTR_style.css
 ---
 

--- a/ottr_website.Rmd
+++ b/ottr_website.Rmd
@@ -1,5 +1,8 @@
 ---
-output: html_document
+output:
+  html_document:
+    includes:
+      in_header: ottr_favicon.html
 css: css/OTTR_style.css
 ---
 

--- a/resources/other_chapters/create_ottr_header.md
+++ b/resources/other_chapters/create_ottr_header.md
@@ -1,0 +1,10 @@
+<link rel="shortcut icon" href="css/images/basic_ottr_water.ico " />
+ <!--- go to https://favicon.io/favicon-converter/ to upload an image to make a new favicon.io. You will need to replace the current favicon.io image with the one in the downloaded directory from the website. The current image is in the resources/images/ directory --->
+
+<div class = "header_box">
+<u>OTTR Quarto Course</u><br><span style = "color:#986753;"> Set Up </span>
+</div>
+
+ <div class = "png_button"><a href="https://github.com/jhudsl/cheatsheets/blob/main/pngs/ottr_quarto_course.png?raw=true">Download cheatsheet</a></div>
+
+ <div class = "time">**Last updated: `r format(Sys.time(), '%B %d, %Y')`** </div>

--- a/resources/other_chapters/starter_template.md
+++ b/resources/other_chapters/starter_template.md
@@ -1,6 +1,6 @@
 
-## [OTTR_Template_Website](https://github.com/jhudsl/OTTR_Template_Website)
+## Create your own repository from the [OTTR_Quarto](https://github.com/fhdsl/OTTR_Quarto) template
 
-<input type="checkbox">  In the upper right, _click on_: <div class = "github_button"> <a href="https://github.com/new?template_name=OTTR_Template_Website"> Use this template</a></div>
+<input type="checkbox">  In the upper right, _click on_: <div class = "github_button"> <a href="https://github.com/new?template_name=OTTR_Quarto"> Use this template</a></div>
 
 <input type="checkbox">  Set your repo to **Public**'

--- a/social_media.Rmd
+++ b/social_media.Rmd
@@ -2,6 +2,8 @@
 output:
   html_document:
     number_sections: false
+    includes:
+      in_header: itn_favicon.html
 css: css/ITN_style.css
 ---
 

--- a/social_media.Rmd
+++ b/social_media.Rmd
@@ -140,9 +140,9 @@ https://www.linkedin.com/company/cancer-genomics-consortium
 - [X](https://twitter.com/itcrtraining): @itcrtraining
 <img src="https://www.iconpacks.net/icons/free-icons-6/free-icon-twitter-x-logo-black-square-rounded-20852.png" width = 10%>
 :::
-<center>
+</center>
 </div>
-</div>
+</div> 
 
 <hr>
 


### PR DESCRIPTION
- missing a line in the social media cheatsheet, trying to fix that and warnings - was an unclosed `<center>` even though it gave warnings about `<div>`
- adding space around ottr header so download button can always be on right - did so by adding `margin = auto` in the css for the header box- also added some `margin-top` space before the time - which also has style specified in the css.
- also fixed the links so they always show white even when visited for the ottr github buttons in the css
- removing old[create_repository.md](https://github.com/jhudsl/cheatsheets/pull/25/files#diff-89120f3c60e139cce5ee6bb488866b390396b9cd3c73ade007baea07e3c1a9ad) as it is no longer used
- moving favicon out of chunks... needs to be defined in header somehow - so better to just have files that are just for the favicon that we can always use I think these are `itn_favicon.html` and `ottr_favicon.html`